### PR TITLE
Using functions as default parameters for class constructors will cause them to only be executed once during initialization.

### DIFF
--- a/python/initialize-attributes-from-function/initialize-attributes-from-function.py
+++ b/python/initialize-attributes-from-function/initialize-attributes-from-function.py
@@ -1,0 +1,23 @@
+import random
+
+def generate_id(length:int) -> str:
+	"""Generate a random ID string of specified length"""
+	print("A new random ID has been requested!")
+	return ''.join(random.choices('0123456789abcdef', k=length))
+
+class Demo:
+	"""A class representing a demo object with an ID"""
+	def __init__(self,id = generate_id(6)):
+		"""Instantiate the demo object with the ID from the 'id' parameter."""
+		self.id = id
+
+print('Starting script execution!')
+
+# Create two objects with an empty constructor, 
+# relying on the constructor's default values to populate the fields
+demo_object_a = Demo()
+demo_object_b = Demo() 
+
+# Print the IDs of the two demo objects
+print(f'Random(?) ID of object a: {demo_object_a.id}')
+print(f'Random(?) ID of object b: {demo_object_b.id}')

--- a/python/initialize-attributes-from-function/readme.md
+++ b/python/initialize-attributes-from-function/readme.md
@@ -1,0 +1,7 @@
+## Using functions as default parameters for class constructors will cause them to only be executed once during initialization.
+
+Looking at the code in `initialize-attributes-from-function.py` one might expect that the two demo objects would get different random IDs, but they don't.
+Instead, the `generate_id` method is only called once during class initialization and the value is then reused for all following calls of the constructor.
+No warnings are generated from all of this (at least not using my VSCode setup) and the entire code seems to work perfectly fine until a second object of the affected class is created and the ids are compared.
+
+(Tested in Python 3.10.7)


### PR DESCRIPTION
Using functions as default parameters for class constructors will cause them to only be executed once during initialization.

Had a lot of fun with that one.