### PR TITLE
Additions to js/schrodingers-regex

### DIFF
--- a/js/schrodingers-regex/README.md
+++ b/js/schrodingers-regex/README.md
@@ -1,5 +1,7 @@
 <h1 align="center"><b>Schrodinger's regex</b></h1>
 
+> Tested using NodeJS v18.13.0<br>But this should function in [all modern javascript engines](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex#browser_compatibility).
+
 Regular expressions in javascript can be funky.<br>Let's look at an example.
 
 ---

--- a/js/schrodingers-regex/regex.js
+++ b/js/schrodingers-regex/regex.js
@@ -1,14 +1,14 @@
 //Create a regex for the string "Test" with the global flag enabled
 const regex = new RegExp(/Test/g);
-//Create an array of big strings with content "Testing" to test against
-const string = "Testing";
+//Create a "big" string with content "Testing" to test against
+const bigString = "Testing";
 
 //Run test (Expected result: True; Actual result: True)
-console.log(regex.test(string));
+console.log(regex.test(bigString));
 //Run test (Expected result: True; Actual result: False)
-console.log(regex.test(string));
+console.log(regex.test(bigString));
 //Run test (Expected result: True; Actual result: True)
-console.log(regex.test(string));
+console.log(regex.test(bigString));
 //Run test (Expected result: True; Actual result: False)
-console.log(regex.test(string));
+console.log(regex.test(bigString));
 // ...


### PR DESCRIPTION
Fixed incorrect leftover comments in code referencing non-existing array.
Added language information.