### PR TITLE
Java Unicode Escapes: Demonstrate Underhandedness

### DIFF
--- a/java/unicode-escapes/README.md
+++ b/java/unicode-escapes/README.md
@@ -1,5 +1,11 @@
 # Unicode escapes
 
 Java allows unicode escapes in the form of `\` followed by at least one `u`
-followed by four hex digits representing the unicode code point. This
+followed by four hex digits representing the unicode code point. Notably this
 isn't limited to string and character literals.
+
+In the example, there is no difference between using `Object.equals` and
+`String.contentEquals`. Instead, the `\u000A` in the line comment on line 8
+gets parsed as a newline, ending the comment, so the following `!` is considered
+part of the boolean expression and negates it. Nevertheless, most syntax highlighting
+engines are not aware of this and treat it as a comment.

--- a/java/unicode-escapes/unicode-escapes.java
+++ b/java/unicode-escapes/unicode-escapes.java
@@ -1,3 +1,24 @@
-\uuuuu002f\u002f This is a valid Java file.
+class Main {
+    public static void main(String... args) {
+        var string =
+            // Java source files are UTF-8, so you can use any unicode directly
+            // in string literals (though the string is represented in UTF-16)!
+            "Hä?";
+        var match =
+            // But string literals can also have unicode escapes like \u000A!
+            string.equals("H\u00E4?");
 
-class\u0020Foo\uu007b}
+        if (match) {
+            // But something strange is going on...
+            System.out.println("This never prints!");
+        }
+
+        var chars_match =
+            // Yet if we treat it as a CharSequence...
+            string.contentEquals("H\u00E4?");
+
+        if (chars_match) {
+            System.out.println("This prints!");
+        }
+    }
+}


### PR DESCRIPTION
The previous example showed that the quirk existed, but it was only surprising that the file compiled. The new example shows how this can actually lead to very unexpected behavior.