### PR TITLE
Update tri-state-maps.java

### DIFF
--- a/java/tri-state-maps/tri-state-maps.java
+++ b/java/tri-state-maps/tri-state-maps.java
@@ -1,9 +1,12 @@
 class Main {
     public static void main(String... args) {
-        var map = java.util.Map.of("foo", 42, "bar", null, "baz": 0);
+        Map<String, Integer> map = new HashMap<>();
+        map.put("foo", 42);
+        map.put("bar", null);
+        map.put("baz", 0);
         if (map.containsKey("bar")) {
             // Throws NullPointerException
-            int bar = map.get("foo");
+            int bar = map.get("bar");
             System.out.println("Bar: "+bar);
         } else {
             System.out.println("Bar not in map");


### PR DESCRIPTION
Fix a couple of issues with the tri state maps example:
- Use of `:` on Map.of which is not legal in Java (when declaring baz)
- Implementation of Map.of does not support null key / values (HashMap does)
- In line 9 you probably meant to get bar (which you ensured exists in line 7), which does reproduce the exception while code in the repo just doesn't compile